### PR TITLE
Restrict OI caps for deprecated markets

### DIFF
--- a/packages/tomls/src/omnibus/reya_cronos.toml
+++ b/packages/tomls/src/omnibus/reya_cronos.toml
@@ -17,7 +17,7 @@ include = [
     "../sbt/testnet.toml",
 ]
 
-version = "1.0.131"
+version = "1.0.132"
 
 [var.chain_ids]
 ethereumSepoliaChainId = "11155111"
@@ -1111,7 +1111,7 @@ market14Sei_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_15zro]
 market15Zro_riskMatrixIndex = "0"
-market15Zro_maxOpenBaseUnscaled = "54057"
+market15Zro_maxOpenBaseUnscaled = "4684"
 market15Zro_velocityMultiplierUnscaled = "37.2"
 market15Zro_oracleNodeId = "<%= settings.zroUsdcMarkNodeIdStork %>"
 market15Zro_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1311,7 +1311,7 @@ market24Bnb_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_25Jto]
 market25Jto_riskMatrixIndex = "0"
-market25Jto_maxOpenBaseUnscaled = "2000"
+market25Jto_maxOpenBaseUnscaled = "2875"
 market25Jto_velocityMultiplierUnscaled = "135"
 market25Jto_oracleNodeId = "<%= settings.jtoUsdcMarkNodeIdStork %>"
 market25Jto_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1711,7 +1711,7 @@ market44Virtual_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_45Ai16z]
 market45Ai16z_riskMatrixIndex = "0"
-market45Ai16z_maxOpenBaseUnscaled = "3142291"
+market45Ai16z_maxOpenBaseUnscaled = "7192"
 market45Ai16z_velocityMultiplierUnscaled = "75"
 market45Ai16z_oracleNodeId = "<%= settings.ai16zUsdcMarkNodeIdStork %>"
 market45Ai16z_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1951,7 +1951,7 @@ market56Inj_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_57Move]
 market57Move_riskMatrixIndex = "0"
-market57Move_maxOpenBaseUnscaled = "5307334"
+market57Move_maxOpenBaseUnscaled = "99652"
 market57Move_velocityMultiplierUnscaled = "23.7"
 market57Move_oracleNodeId = "<%= settings.moveUsdcMarkNodeIdStork %>"
 market57Move_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1971,7 +1971,7 @@ market57Move_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_58Bera]
 market58Bera_riskMatrixIndex = "0"
-market58Bera_maxOpenBaseUnscaled = "10000"
+market58Bera_maxOpenBaseUnscaled = "1888"
 market58Bera_velocityMultiplierUnscaled = "75"
 market58Bera_oracleNodeId = "<%= settings.beraUsdcMarkNodeIdStork %>"
 market58Bera_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2071,7 +2071,7 @@ market62Me_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_63Pump]
 market63Pump_riskMatrixIndex = "0"
-market63Pump_maxOpenBaseUnscaled = "55692008"
+market63Pump_maxOpenBaseUnscaled = "259021"
 market63Pump_velocityMultiplierUnscaled = "70.3"
 market63Pump_oracleNodeId = "<%= settings.pumpUsdcMarkNodeIdStork %>"
 market63Pump_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2171,7 +2171,7 @@ market67Kaito_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_68Zora]
 market68Zora_riskMatrixIndex = "0"
-market68Zora_maxOpenBaseUnscaled = "6433556"
+market68Zora_maxOpenBaseUnscaled = "17029"
 market68Zora_velocityMultiplierUnscaled = "29.3"
 market68Zora_oracleNodeId = "<%= settings.zoraUsdcMarkNodeIdStork %>"
 market68Zora_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2191,7 +2191,7 @@ market68Zora_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_69Prove]
 market69Prove_riskMatrixIndex = "0"
-market69Prove_maxOpenBaseUnscaled = "428077"
+market69Prove_maxOpenBaseUnscaled = "235705"
 market69Prove_velocityMultiplierUnscaled = "23.7"
 market69Prove_oracleNodeId = "<%= settings.proveUsdcMarkNodeIdStork %>"
 market69Prove_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2231,7 +2231,7 @@ market70Paxg_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_71Yzy]
 market71Yzy_riskMatrixIndex = "0"
-market71Yzy_maxOpenBaseUnscaled = "339856"
+market71Yzy_maxOpenBaseUnscaled = "7"
 market71Yzy_velocityMultiplierUnscaled = "8.8"
 market71Yzy_oracleNodeId = "<%= settings.yzyUsdcMarkNodeIdStork %>"
 market71Yzy_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2251,7 +2251,7 @@ market71Yzy_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_72Xpl]
 market72Xpl_riskMatrixIndex = "0"
-market72Xpl_maxOpenBaseUnscaled = "1110467"
+market72Xpl_maxOpenBaseUnscaled = "7872"
 market72Xpl_velocityMultiplierUnscaled = "56.8"
 market72Xpl_oracleNodeId = "<%= settings.xplUsdcMarkNodeIdStork %>"
 market72Xpl_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2271,7 +2271,7 @@ market72Xpl_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_73Wlfi]
 market73Wlfi_riskMatrixIndex = "0"
-market73Wlfi_maxOpenBaseUnscaled = "1091243"
+market73Wlfi_maxOpenBaseUnscaled = "249"
 market73Wlfi_velocityMultiplierUnscaled = "52.1"
 market73Wlfi_oracleNodeId = "<%= settings.wlfiUsdcMarkNodeIdStork %>"
 market73Wlfi_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2311,7 +2311,7 @@ market74Linea_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_75Mega]
 market75Mega_riskMatrixIndex = "0"
-market75Mega_maxOpenBaseUnscaled = "12500"
+market75Mega_maxOpenBaseUnscaled = "339"
 market75Mega_velocityMultiplierUnscaled = "1.4"
 market75Mega_oracleNodeId = "<%= settings.megaUsdcMarkNodeIdStork %>"
 market75Mega_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -18,7 +18,7 @@ include = [
     "../rotations/mainnet.toml",
 ]
 
-version = "1.0.146"
+version = "1.0.147"
 
 [var.chain_ids]
 ethereumChainId = "1"
@@ -1174,7 +1174,7 @@ market14Sei_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_15zro]
 market15Zro_riskMatrixIndex = "0"
-market15Zro_maxOpenBaseUnscaled = "54057"
+market15Zro_maxOpenBaseUnscaled = "4684"
 market15Zro_velocityMultiplierUnscaled = "37.2"
 market15Zro_oracleNodeId = "<%= settings.zroUsdcMarkNodeIdStork %>"
 market15Zro_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1374,7 +1374,7 @@ market24Bnb_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_25Jto]
 market25Jto_riskMatrixIndex = "0"
-market25Jto_maxOpenBaseUnscaled = "2300"
+market25Jto_maxOpenBaseUnscaled = "2875"
 market25Jto_velocityMultiplierUnscaled = "135"
 market25Jto_oracleNodeId = "<%= settings.jtoUsdcMarkNodeIdStork %>"
 market25Jto_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1774,7 +1774,7 @@ market44Virtual_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_45Ai16z]
 market45Ai16z_riskMatrixIndex = "0"
-market45Ai16z_maxOpenBaseUnscaled = "3142291"
+market45Ai16z_maxOpenBaseUnscaled = "7192"
 market45Ai16z_velocityMultiplierUnscaled = "75"
 market45Ai16z_oracleNodeId = "<%= settings.ai16zUsdcMarkNodeIdStork %>"
 market45Ai16z_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2014,7 +2014,7 @@ market56Inj_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_57Move]
 market57Move_riskMatrixIndex = "0"
-market57Move_maxOpenBaseUnscaled = "5307334"
+market57Move_maxOpenBaseUnscaled = "99652"
 market57Move_velocityMultiplierUnscaled = "23.7"
 market57Move_oracleNodeId = "<%= settings.moveUsdcMarkNodeIdStork %>"
 market57Move_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2034,7 +2034,7 @@ market57Move_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_58Bera]
 market58Bera_riskMatrixIndex = "0"
-market58Bera_maxOpenBaseUnscaled = "10000"
+market58Bera_maxOpenBaseUnscaled = "1888"
 market58Bera_velocityMultiplierUnscaled = "75"
 market58Bera_oracleNodeId = "<%= settings.beraUsdcMarkNodeIdStork %>"
 market58Bera_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2134,7 +2134,7 @@ market62Me_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_63Pump]
 market63Pump_riskMatrixIndex = "0"
-market63Pump_maxOpenBaseUnscaled = "55692008"
+market63Pump_maxOpenBaseUnscaled = "259021"
 market63Pump_velocityMultiplierUnscaled = "70.3"
 market63Pump_oracleNodeId = "<%= settings.pumpUsdcMarkNodeIdStork %>"
 market63Pump_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2234,7 +2234,7 @@ market67Kaito_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_68Zora]
 market68Zora_riskMatrixIndex = "0"
-market68Zora_maxOpenBaseUnscaled = "6433556"
+market68Zora_maxOpenBaseUnscaled = "17029"
 market68Zora_velocityMultiplierUnscaled = "29.3"
 market68Zora_oracleNodeId = "<%= settings.zoraUsdcMarkNodeIdStork %>"
 market68Zora_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2254,7 +2254,7 @@ market68Zora_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_69Prove]
 market69Prove_riskMatrixIndex = "0"
-market69Prove_maxOpenBaseUnscaled = "428077"
+market69Prove_maxOpenBaseUnscaled = "235705"
 market69Prove_velocityMultiplierUnscaled = "23.7"
 market69Prove_oracleNodeId = "<%= settings.proveUsdcMarkNodeIdStork %>"
 market69Prove_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2294,7 +2294,7 @@ market70Paxg_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_71Yzy]
 market71Yzy_riskMatrixIndex = "0"
-market71Yzy_maxOpenBaseUnscaled = "339856"
+market71Yzy_maxOpenBaseUnscaled = "7"
 market71Yzy_velocityMultiplierUnscaled = "8.8"
 market71Yzy_oracleNodeId = "<%= settings.yzyUsdcMarkNodeIdStork %>"
 market71Yzy_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2314,7 +2314,7 @@ market71Yzy_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_72Xpl]
 market72Xpl_riskMatrixIndex = "0"
-market72Xpl_maxOpenBaseUnscaled = "1110467"
+market72Xpl_maxOpenBaseUnscaled = "7872"
 market72Xpl_velocityMultiplierUnscaled = "56.8"
 market72Xpl_oracleNodeId = "<%= settings.xplUsdcMarkNodeIdStork %>"
 market72Xpl_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2334,7 +2334,7 @@ market72Xpl_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_73Wlfi]
 market73Wlfi_riskMatrixIndex = "0"
-market73Wlfi_maxOpenBaseUnscaled = "1091243"
+market73Wlfi_maxOpenBaseUnscaled = "249"
 market73Wlfi_velocityMultiplierUnscaled = "52.1"
 market73Wlfi_oracleNodeId = "<%= settings.wlfiUsdcMarkNodeIdStork %>"
 market73Wlfi_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2374,7 +2374,7 @@ market74Linea_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_75Mega]
 market75Mega_riskMatrixIndex = "0"
-market75Mega_maxOpenBaseUnscaled = "12500"
+market75Mega_maxOpenBaseUnscaled = "339"
 market75Mega_velocityMultiplierUnscaled = "1.4"
 market75Mega_oracleNodeId = "<%= settings.megaUsdcMarkNodeIdStork %>"
 market75Mega_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"


### PR DESCRIPTION
AI16Z, BERA, JTO, MEGA, MOVE, PROVE, PUMP, WLFI, XPL, YZY, ZORA, ZRO)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configuration updates deployed for reya_cronos (v1.0.131 → v1.0.132) and reya_network (v1.0.146 → v1.0.147). Market operation parameters adjusted for 12 trading pairs across both network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->