### PR TITLE
feat: update spread discount

### DIFF
--- a/packages/tomls/src/omnibus/reya_cronos.toml
+++ b/packages/tomls/src/omnibus/reya_cronos.toml
@@ -17,7 +17,7 @@ include = [
     "../sbt/testnet.toml",
 ]
 
-version = "1.0.131"
+version = "1.0.132"
 
 [var.chain_ids]
 ethereumSepoliaChainId = "11155111"
@@ -536,7 +536,7 @@ refereeDiscountUnscaled = "0.1"
 referrerRebateUnscaled = "0.1"
 affiliateReferrerRebateUnscaled = "0.15"
 vltzDiscountUnscaled = "0.1"
-spreadDiscountUnscaled = "1.0"
+spreadDiscountUnscaled = "0.5"
 
 [var.affiliates]
 affiliate1 = "0xae173a960084903b1d278ff9e3a81ded82275556"

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -602,7 +602,7 @@ refereeDiscountUnscaled = "0.1"
 referrerRebateUnscaled = "0.1"
 affiliateReferrerRebateUnscaled = "0.15"
 vltzDiscountUnscaled = "0.1"
-spreadDiscountUnscaled = "1.0"
+spreadDiscountUnscaled = "0.5"
 
 [var.affiliates]
 affiliate1 = "0xae173a960084903b1d278ff9e3a81ded82275556"

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -18,7 +18,7 @@ include = [
     "../rotations/mainnet.toml",
 ]
 
-version = "1.0.146"
+version = "1.0.147"
 
 [var.chain_ids]
 ethereumChainId = "1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Reya Network fee configuration parameter has been adjusted. The spread discount unscaled value has been modified from 1.0 to 0.5, changing how trading fees and spreads are calculated on the network. This update affects fee configuration behavior across platform operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->