### PR TITLE
fix(tests): refresh stale price fixtures for TIA, NEAR, GRASS, AERO

### DIFF
--- a/packages/tests/test/reya_common/general/General.fork.c.sol
+++ b/packages/tests/test/reya_common/general/General.fork.c.sol
@@ -283,7 +283,7 @@ contract GeneralForkCheck is BaseReyaForkTest {
         ls.meanPriceMarket.push(ls.meanPriceSUI);
         ls.maxDeviationMarket.push(ls.maxDeviationSUI);
 
-        ls.meanPriceTIA = 0.3 * 1e18;
+        ls.meanPriceTIA = 0.47 * 1e18;
         ls.maxDeviationTIA = ls.meanPriceTIA / 2;
         ls.meanPriceMarket.push(ls.meanPriceTIA);
         ls.maxDeviationMarket.push(ls.maxDeviationTIA);
@@ -363,7 +363,7 @@ contract GeneralForkCheck is BaseReyaForkTest {
         ls.meanPriceMarket.push(ls.meanPricePOL);
         ls.maxDeviationMarket.push(ls.maxDeviationPOL);
 
-        ls.meanPriceNEAR = 1.7 * 1e18;
+        ls.meanPriceNEAR = 2.75 * 1e18;
         ls.maxDeviationNEAR = ls.meanPriceNEAR / 2;
         ls.meanPriceMarket.push(ls.meanPriceNEAR);
         ls.maxDeviationMarket.push(ls.maxDeviationNEAR);
@@ -394,7 +394,7 @@ contract GeneralForkCheck is BaseReyaForkTest {
         ls.meanPriceMarket.push(ls.meanPriceGOAT);
         ls.maxDeviationMarket.push(ls.maxDeviationGOAT);
 
-        ls.meanPriceGRASS = 0.29 * 1e18;
+        ls.meanPriceGRASS = 0.56 * 1e18;
         ls.maxDeviationGRASS = ls.meanPriceGRASS / 2;
         ls.meanPriceMarket.push(ls.meanPriceGRASS);
         ls.maxDeviationMarket.push(ls.maxDeviationGRASS);
@@ -550,7 +550,7 @@ contract GeneralForkCheck is BaseReyaForkTest {
         ls.meanPriceMarket.push(ls.meanPriceSYRUP);
         ls.maxDeviationMarket.push(ls.maxDeviationSYRUP);
 
-        ls.meanPriceAERO = 0.28 * 1e18;
+        ls.meanPriceAERO = 0.44 * 1e18;
         ls.maxDeviationAERO = ls.meanPriceAERO / 2;
         ls.meanPriceMarket.push(ls.meanPriceAERO);
         ls.maxDeviationMarket.push(ls.maxDeviationAERO);


### PR DESCRIPTION
## Summary

Follow-up to [#474](https://github.com/Reya-Labs/reya-deployments/pull/474). Same pattern: \`test_MarketsPrices\` and \`test_OracleManager\` in [\`General.fork.c.sol\`](https://github.com/Reya-Labs/reya-deployments/blob/main/packages/tests/test/reya_common/general/General.fork.c.sol) compare on-chain oracle output against hardcoded \`ls.meanPrice<TOKEN>\` constants with a ±50% tolerance (\`maxDeviation<TOKEN> = mean / 2\`). Four more tokens have drifted past the band since the May 20 refresh.

## Failing tests

Surfaced by the network test run on [#475](https://github.com/Reya-Labs/reya-deployments/pull/475):

\`\`\`
[FAIL] test_MarketsPrices()    — market IDs 66, 35, 29, 13
[FAIL] test_OracleManager()    — 8 node IDs (2 per market: USD + USDC variants)
\`\`\`

## Refresh

CoinGecko spot pulled 2026-05-25:

| Token | Mkt | Fixture | Band | Spot | New mean |
|-------|-----|---------|------|------|----------|
| TIA | 13 | 0.30 | [0.15, 0.45] | $0.473 | **0.47** |
| NEAR | 29 | 1.7 | [0.85, 2.55] | $2.75 | **2.75** |
| GRASS | 35 | 0.29 | [0.145, 0.435] | $0.560 | **0.56** |
| AERO | 66 | 0.28 | [0.14, 0.42] | $0.440 | **0.44** |

Each new mean is within ~2% of current spot; the ±50% band gives ample headroom before next drift trip. Other tokens were within tolerance in the failing run and are left untouched.

## Rationale (same as #474)

Refresh over widening tolerance or removing the assertion — the test catches real sanity-check regressions (broken oracle wiring returning zero, wrong unit, etc.), and a 2× band is the minimum that still does so.

## Test plan

- [ ] CI passes \`test_MarketsPrices\` and \`test_OracleManager\` in \`General.fork.t.sol\` (mainnet) and the cronos analogue
- [ ] No other tests regress

## Followup (not blocking)

Same as #474: the failing-fixture pattern recurs every few weeks as crypto prices move. Two options for a more durable fix:
1. Replace hardcoded means with a runtime pull from a reference oracle (e.g. cross-checking against a Chainlink feed on the same chain) — keeps the sanity check but auto-tracks the price
2. Tag the test with a \"last refreshed\" timestamp comment and add a pre-commit hook that flags fixtures older than N months

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated oracle node price test parameters for asset validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reya-Labs/reya-deployments/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->