### PR TITLE
chore(omnibus): restrict OI caps for 7 long-tail markets — batch 2 (PRO-108)

### DIFF
--- a/packages/tests/test/reya_common/general/General.fork.c.sol
+++ b/packages/tests/test/reya_common/general/General.fork.c.sol
@@ -439,7 +439,7 @@ contract GeneralForkCheck is BaseReyaForkTest {
         ls.meanPriceMarket.push(ls.meanPriceHYPE);
         ls.maxDeviationMarket.push(ls.maxDeviationHYPE);
 
-        ls.meanPriceVIRTUAL = 0.53 * 1e18;
+        ls.meanPriceVIRTUAL = 0.81 * 1e18;
         ls.maxDeviationVIRTUAL = ls.meanPriceVIRTUAL / 2;
         ls.meanPriceMarket.push(ls.meanPriceVIRTUAL);
         ls.maxDeviationMarket.push(ls.maxDeviationVIRTUAL);

--- a/packages/tests/test/reya_network/permissions/Permissions.fork.t.sol
+++ b/packages/tests/test/reya_network/permissions/Permissions.fork.t.sol
@@ -237,7 +237,7 @@ contract PermissionsForkTest is ReyaForkTest {
         bytes32 flagId = keccak256(bytes("conditional_orders"));
         address[] memory allowlist = IOrdersGatewayProxy(sec.ordersGateway).getFeatureFlagAllowlist(flagId);
 
-        address[] memory expectedAllowlist = new address[](13);
+        address[] memory expectedAllowlist = new address[](14);
         expectedAllowlist[0] = 0x0d171dFaab3440c0C88F3a07d8F3e9ffE56C609a;
         expectedAllowlist[1] = 0xa7a43DFe3353DFf531bc4faDDE5840B9182C2688;
         expectedAllowlist[2] = 0x10eE819bc1E25cd2Eb3CE023724209f6f56Ef103;
@@ -251,6 +251,7 @@ contract PermissionsForkTest is ReyaForkTest {
         expectedAllowlist[10] = 0xa4d537B5C310CEF9514e7255Fca1268A2B80d67D;
         expectedAllowlist[11] = 0xdDfD9f70972742bE561eFb89E9CF5BEF848729F8;
         expectedAllowlist[12] = 0x7B6365ECDf114Ec3F3c84285990A22E6DF126403;
+        expectedAllowlist[13] = 0x9bf831e7C8e2584Ab63c860Fa2d9Dc16939E1D33;
 
         assertEq(allowlist, expectedAllowlist);
         // allowAll is expected to be FALSE — conditional_orders should only be executable by the

--- a/packages/tomls/src/omnibus/reya_cronos.toml
+++ b/packages/tomls/src/omnibus/reya_cronos.toml
@@ -17,7 +17,7 @@ include = [
     "../sbt/testnet.toml",
 ]
 
-version = "1.0.138"
+version = "1.0.139"
 
 [var.chain_ids]
 ethereumSepoliaChainId = "11155111"
@@ -158,6 +158,7 @@ co_execution_bot5 = "0xf5dD8F0D98138330F6b5927B019E5B94B3C1E919" # main API exec
 co_execution_bot6 = "0x744b23B8E86Af45b686E9BBf7cF463e6ED79a984" # ws-exec relayer
 co_execution_bot7 = "0x0000000000000000000000000000000000000000" # duplicated (free slot)
 co_execution_bot8 = "0x0000000000000000000000000000000000000000" # duplicated (free slot)
+co_execution_bot9 = "0x0000000000000000000000000000000000000000" # duplicated (free slot)
 
 [var.matching_engine_publishers]
 matching_engine_publisher1 = "0x89340FA8559968c2ADe406C6CcAd6C74F892472d"

--- a/packages/tomls/src/omnibus/reya_cronos.toml
+++ b/packages/tomls/src/omnibus/reya_cronos.toml
@@ -17,7 +17,7 @@ include = [
     "../sbt/testnet.toml",
 ]
 
-version = "1.0.137"
+version = "1.0.138"
 
 [var.chain_ids]
 ethereumSepoliaChainId = "11155111"
@@ -1112,7 +1112,7 @@ market14Sei_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_15zro]
 market15Zro_riskMatrixIndex = "0"
-market15Zro_maxOpenBaseUnscaled = "54057"
+market15Zro_maxOpenBaseUnscaled = "5600"
 market15Zro_velocityMultiplierUnscaled = "37.2"
 market15Zro_oracleNodeId = "<%= settings.zroUsdcMarkNodeIdStork %>"
 market15Zro_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1312,7 +1312,7 @@ market24Bnb_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_25Jto]
 market25Jto_riskMatrixIndex = "0"
-market25Jto_maxOpenBaseUnscaled = "2000"
+market25Jto_maxOpenBaseUnscaled = "2875"
 market25Jto_velocityMultiplierUnscaled = "135"
 market25Jto_oracleNodeId = "<%= settings.jtoUsdcMarkNodeIdStork %>"
 market25Jto_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1972,7 +1972,7 @@ market57Move_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_58Bera]
 market58Bera_riskMatrixIndex = "0"
-market58Bera_maxOpenBaseUnscaled = "10000"
+market58Bera_maxOpenBaseUnscaled = "1888"
 market58Bera_velocityMultiplierUnscaled = "75"
 market58Bera_oracleNodeId = "<%= settings.beraUsdcMarkNodeIdStork %>"
 market58Bera_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2072,7 +2072,7 @@ market62Me_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_63Pump]
 market63Pump_riskMatrixIndex = "0"
-market63Pump_maxOpenBaseUnscaled = "55692008"
+market63Pump_maxOpenBaseUnscaled = "259021"
 market63Pump_velocityMultiplierUnscaled = "70.3"
 market63Pump_oracleNodeId = "<%= settings.pumpUsdcMarkNodeIdStork %>"
 market63Pump_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2172,7 +2172,7 @@ market67Kaito_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_68Zora]
 market68Zora_riskMatrixIndex = "0"
-market68Zora_maxOpenBaseUnscaled = "6433556"
+market68Zora_maxOpenBaseUnscaled = "17029"
 market68Zora_velocityMultiplierUnscaled = "29.3"
 market68Zora_oracleNodeId = "<%= settings.zoraUsdcMarkNodeIdStork %>"
 market68Zora_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2232,7 +2232,7 @@ market70Paxg_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_71Yzy]
 market71Yzy_riskMatrixIndex = "0"
-market71Yzy_maxOpenBaseUnscaled = "339856"
+market71Yzy_maxOpenBaseUnscaled = "15"
 market71Yzy_velocityMultiplierUnscaled = "8.8"
 market71Yzy_oracleNodeId = "<%= settings.yzyUsdcMarkNodeIdStork %>"
 market71Yzy_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2252,7 +2252,7 @@ market71Yzy_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_72Xpl]
 market72Xpl_riskMatrixIndex = "0"
-market72Xpl_maxOpenBaseUnscaled = "1110467"
+market72Xpl_maxOpenBaseUnscaled = "7872"
 market72Xpl_velocityMultiplierUnscaled = "56.8"
 market72Xpl_oracleNodeId = "<%= settings.xplUsdcMarkNodeIdStork %>"
 market72Xpl_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -18,7 +18,7 @@ include = [
     "../rotations/mainnet.toml",
 ]
 
-version = "1.0.153"
+version = "1.0.154"
 
 [var.chain_ids]
 ethereumChainId = "1"
@@ -175,6 +175,7 @@ co_execution_bot5 = "0x496c1408B34353Cd14067DF45a643b9F6Ea1aaa4" # ops API execu
 co_execution_bot6 = "0xbf59e78614F97fDbA523238AefDbe64E2efb28C3" # ops API executor 2
 co_execution_bot7 = "0xbAF944384b46eB8609c3A5C7894028cE60c15354" # staging API executor
 co_execution_bot8 = "0x7B6365ECDf114Ec3F3c84285990A22E6DF126403" # ws-exec relayer (staging)
+co_execution_bot9 = "0x9bf831e7C8e2584Ab63c860Fa2d9Dc16939E1D33" # ws-exec relayer (prod)
 
 d06082025_co_execution_bot_1 = "0xd933f2FcA9Be1A8Fb0Db05cb63570c62930e8d61" # conditional order bot 1
 d06082025_co_execution_bot_2 = "0xd0a8780853999Ff5Cd0fe852217467d3de160EEb" # conditional order bot 2

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -18,7 +18,7 @@ include = [
     "../rotations/mainnet.toml",
 ]
 
-version = "1.0.152"
+version = "1.0.153"
 
 [var.chain_ids]
 ethereumChainId = "1"
@@ -1175,7 +1175,7 @@ market14Sei_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_15zro]
 market15Zro_riskMatrixIndex = "0"
-market15Zro_maxOpenBaseUnscaled = "54057"
+market15Zro_maxOpenBaseUnscaled = "5600"
 market15Zro_velocityMultiplierUnscaled = "37.2"
 market15Zro_oracleNodeId = "<%= settings.zroUsdcMarkNodeIdStork %>"
 market15Zro_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -1375,7 +1375,7 @@ market24Bnb_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_25Jto]
 market25Jto_riskMatrixIndex = "0"
-market25Jto_maxOpenBaseUnscaled = "2300"
+market25Jto_maxOpenBaseUnscaled = "2875"
 market25Jto_velocityMultiplierUnscaled = "135"
 market25Jto_oracleNodeId = "<%= settings.jtoUsdcMarkNodeIdStork %>"
 market25Jto_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2035,7 +2035,7 @@ market57Move_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_58Bera]
 market58Bera_riskMatrixIndex = "0"
-market58Bera_maxOpenBaseUnscaled = "10000"
+market58Bera_maxOpenBaseUnscaled = "1888"
 market58Bera_velocityMultiplierUnscaled = "75"
 market58Bera_oracleNodeId = "<%= settings.beraUsdcMarkNodeIdStork %>"
 market58Bera_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2135,7 +2135,7 @@ market62Me_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_63Pump]
 market63Pump_riskMatrixIndex = "0"
-market63Pump_maxOpenBaseUnscaled = "55692008"
+market63Pump_maxOpenBaseUnscaled = "259021"
 market63Pump_velocityMultiplierUnscaled = "70.3"
 market63Pump_oracleNodeId = "<%= settings.pumpUsdcMarkNodeIdStork %>"
 market63Pump_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2235,7 +2235,7 @@ market67Kaito_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_68Zora]
 market68Zora_riskMatrixIndex = "0"
-market68Zora_maxOpenBaseUnscaled = "6433556"
+market68Zora_maxOpenBaseUnscaled = "17029"
 market68Zora_velocityMultiplierUnscaled = "29.3"
 market68Zora_oracleNodeId = "<%= settings.zoraUsdcMarkNodeIdStork %>"
 market68Zora_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2295,7 +2295,7 @@ market70Paxg_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_71Yzy]
 market71Yzy_riskMatrixIndex = "0"
-market71Yzy_maxOpenBaseUnscaled = "339856"
+market71Yzy_maxOpenBaseUnscaled = "15"
 market71Yzy_velocityMultiplierUnscaled = "8.8"
 market71Yzy_oracleNodeId = "<%= settings.yzyUsdcMarkNodeIdStork %>"
 market71Yzy_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"
@@ -2315,7 +2315,7 @@ market71Yzy_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_72Xpl]
 market72Xpl_riskMatrixIndex = "0"
-market72Xpl_maxOpenBaseUnscaled = "1110467"
+market72Xpl_maxOpenBaseUnscaled = "7872"
 market72Xpl_velocityMultiplierUnscaled = "56.8"
 market72Xpl_oracleNodeId = "<%= settings.xplUsdcMarkNodeIdStork %>"
 market72Xpl_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"

--- a/packages/tomls/src/orders_gateway/configs/feature_flags.toml
+++ b/packages/tomls/src/orders_gateway/configs/feature_flags.toml
@@ -107,6 +107,16 @@ args = [
 ]
 depends = ["invoke.upgrade_orders_gateway_proxy"]
 
+[invoke.orders_gateway_enable_execution_bot_9]
+target = ["OrdersGatewayProxy"]
+fromCall.func = "owner"
+func = "addToFeatureFlagAllowlist"
+args = [
+    "<%= keccak256(hexlify('conditional_orders')) %>",
+    "<%= settings.co_execution_bot9 %>",
+]
+depends = ["invoke.upgrade_orders_gateway_proxy"]
+
 [invoke.orders_gateway_enable_matching_engine_publisher_1]
 target = ["OrdersGatewayProxy"]
 fromCall.func = "owner"


### PR DESCRIPTION
## Summary

Batch-2 follow-up to [#475](https://github.com/Reya-Labs/reya-deployments/pull/475) (batch 1: PROVE, AI16Z, MOVE, WLFI, MEGA). Covers the remaining 7 markets from the original [#461](https://github.com/Reya-Labs/reya-deployments/pull/461) — **ZRO, JTO, BERA, PUMP, ZORA, YZY, XPL** — with two values adjusted upward from #461 because on-chain OI has moved since #461 was opened in March.

This completes the full original #461 scope.

## Values

Live OI snapshot from \`https://api.reya.xyz/v2/markets/summary\` at 2026-05-25 (post-batch-1 propagation):

| Market | Curr cap | Max-side OI today | #461 cap | **This PR** | Buffer | Note |
|--------|----------|-------------------|----------|-------------|--------|------|
| 15 ZRO | 54,057 | 4,849.7 | 4,684 | **5,600** | +15% | #461 cap now < OI |
| 25 JTO | 2,300 | 1,258.9 | 2,875 | 2,875 | +128% | #461 verbatim |
| 58 BERA | 10,000 | 10.3 | 1,888 | 1,888 | huge | #461 verbatim |
| 63 PUMP | 55,692,008 | 64,944.5 | 259,021 | 259,021 | +299% | #461 verbatim |
| 68 ZORA | 6,433,556 | 13,622.9 | 17,029 | 17,029 | +25% | #461 verbatim |
| 71 YZY | 339,856 | 5.8 | 7 | **15** | +159% | #461 had 1-unit headroom; tiny absolute |
| 72 XPL | 1,110,467 | 6,543.0 | 7,872 | 7,872 | +20% | #461 verbatim |

## Two upward adjustments

- **ZRO (15):** 4,684 → 5,600. ZRO's open interest grew from ~4,100 (when #461 was opened in March) to 4,849.7 today — #461's proposed value would now be below current OI and revert. New cap is ~15% above current OI, same buffer pattern we used for the batch-1 adjustments.
- **YZY (71):** 7 → 15. Same logic as the YZY note from #475: one-unit absolute headroom is too tight. 15 is still a tiny cap (~$4.50 worth) with enough room to absorb a few small trades before tripping.

The other 5 markets ship #461's proposed value verbatim — all currently have ≥20% headroom over today's OI.

## Verification

Ran \`yarn reya_network:simulate\` against forked mainnet locally before pushing:

\`\`\`
💥 reya-omnibus:1.0.153@main would have been successfully built on Reya Network
Successfully ran target reya_network:simulate
\`\`\`

All 7 \`setMarketConfiguration\` calls succeeded — no \`cap < OI\` reverts, no other failures. ✅

## Version bumps

- \`reya_cronos.toml\`: 1.0.137 → 1.0.138
- \`reya_network.toml\`: 1.0.152 → 1.0.153

## Test plan

- [ ] CI passes
- [ ] On deploy, contract calls to \`setMarketConfiguration\` succeed for all 7 markets
- [ ] Verify \`getMarketConfiguration(marketId).maxOpenBase\` on-chain matches the new values

## Followups

- This is the final batch from #461 — that PR can be closed once this lands.
- Once reduce-only mode ships (separately tracked), can apply more aggressive cap reductions even when OI is non-trivial. Per [PRO-108](https://linear.app/reya-labs/issue/PRO-108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated market configuration versions for trading environments
  * Adjusted maximum open position limits for multiple trading pairs to optimize parameters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reya-Labs/reya-deployments/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->