### PR TITLE
chore(omnibus): bump ZRO cap 5,600 → 23,000 (PRO-108 batch 2 retry)

### DIFF
--- a/packages/tomls/src/omnibus/reya_cronos.toml
+++ b/packages/tomls/src/omnibus/reya_cronos.toml
@@ -17,7 +17,7 @@ include = [
     "../sbt/testnet.toml",
 ]
 
-version = "1.0.139"
+version = "1.0.140"
 
 [var.chain_ids]
 ethereumSepoliaChainId = "11155111"
@@ -1113,7 +1113,7 @@ market14Sei_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_15zro]
 market15Zro_riskMatrixIndex = "0"
-market15Zro_maxOpenBaseUnscaled = "5600"
+market15Zro_maxOpenBaseUnscaled = "23000"
 market15Zro_velocityMultiplierUnscaled = "37.2"
 market15Zro_oracleNodeId = "<%= settings.zroUsdcMarkNodeIdStork %>"
 market15Zro_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -18,7 +18,7 @@ include = [
     "../rotations/mainnet.toml",
 ]
 
-version = "1.0.154"
+version = "1.0.155"
 
 [var.chain_ids]
 ethereumChainId = "1"
@@ -1176,7 +1176,7 @@ market14Sei_volatilityIndexMultiplierUnscaled = "0"
 
 [var.market_15zro]
 market15Zro_riskMatrixIndex = "0"
-market15Zro_maxOpenBaseUnscaled = "5600"
+market15Zro_maxOpenBaseUnscaled = "23000"
 market15Zro_velocityMultiplierUnscaled = "37.2"
 market15Zro_oracleNodeId = "<%= settings.zroUsdcMarkNodeIdStork %>"
 market15Zro_mtmWindow = "<%= 500 * settings.ONE_YEAR_IN_SECONDS %>"


### PR DESCRIPTION
## Summary

Bump market-15 (ZRO) \`maxOpenBaseUnscaled\` from 5,600 → **23,000** to retry batch 2 ([#477](https://github.com/Reya-Labs/reya-deployments/pull/477)).

## Why

The PR #477 multisig batch ([tx 0x829dc2...](https://explorer.reya.network/tx/0x829dc2b829d62c4a68f491cb18ec5ec094a3b0a0bd622aa8bb809c906ba58371)) reverted atomically — Safe emitted \`ExecutionFailure\` because \`setMarketConfiguration(15, ...)\` for ZRO failed with the contract's \`"MAXOI"\` custom error (proposed cap below current on-chain OI).

Between PR #477 sign-off and multisig execution:
- ZRO long OI:  4,100 → 8,100 (+98%)
- ZRO short OI: 2,683 → **15,411** (+474%)
- Max-side OI: 4,849 → 15,411 (~**3×** growth in hours)

The 5,600 cap is now ~10k below current OI.

## What this PR does

Single-line change in both omnibus tomls: ZRO \`maxOpenBaseUnscaled\` 5,600 → 23,000 (~**50% buffer** over current 15,411 OI).

Larger buffer than batch-1's +15-28% pattern is intentional: ZRO has demonstrated it can grow 3× in a few hours, and we don't want to whack-a-mole this through more failed batches. 23,000 base @ $1.29 ≈ $30k — still far tighter than the original 54,057 (~$70k) cap.

## What cannon will deploy next

Since #477's GitHub merge ≠ on-chain deploy (the batch reverted atomically), the on-chain state for ALL 7 markets and the bot9 whitelist is still the pre-#477 state. Cannon's next batch will pick up:

- **ZRO** at **23,000** (this PR's value)
- The other 6 OI cap changes from #477 (JTO, BERA, PUMP, ZORA, YZY, XPL) — still pending on-chain
- bot9 (prod ws-exec relayer) whitelist — also still pending on-chain

So one tiny PR retries the entire batch-2 + ws-exec scope.

## Verification

\`yarn reya_network:simulate\` against forked mainnet:

\`\`\`
✔ Successfully called setMarketConfiguration(15, {maxOpenBase: 23000000000000000000000, ...})
Successfully ran target reya_network:simulate
\`\`\`

All other still-pending invokes from #477 also resolve cleanly in the same simulate.

## Version bumps

- \`reya_cronos.toml\`: 1.0.139 → 1.0.140
- \`reya_network.toml\`: 1.0.154 → 1.0.155

## Test plan

- [ ] CI green
- [ ] Re-stage the cannon deploy package and collect signatures
- [ ] Multisig execution succeeds (no \`ExecutionFailure\`)
- [ ] Verify on-chain: \`getMarketConfiguration(15).maxOpenBase\` == 23,000 × 1e18
- [ ] Verify the other 6 caps + bot9 whitelist also land

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system configuration versions across network environments
  * Increased ZRO market configuration limits to 23,000, representing a significant expansion from previous thresholds to accommodate expanded market operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reya-Labs/reya-deployments/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->