### PR TITLE
chore(omnibus): disable rAmber per-window withdrawal rate limit

### DIFF
--- a/packages/tomls/src/omnibus/reya_cronos.toml
+++ b/packages/tomls/src/omnibus/reya_cronos.toml
@@ -17,7 +17,7 @@ include = [
     "../sbt/testnet.toml",
 ]
 
-version = "1.0.140"
+version = "1.0.141"
 
 [var.chain_ids]
 ethereumSepoliaChainId = "11155111"
@@ -489,7 +489,7 @@ rseliniWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
 rseliniWithdrawalTvlPercentageLimitUnscaled = "0"
 # -------------------------------------------------------------------
 ramberCollateralAdapter = "<%= AddressZero %>"
-ramberWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
+ramberWithdrawalWindowSize = "0"
 ramberWithdrawalTvlPercentageLimitUnscaled = "1"
 # -------------------------------------------------------------------
 rhedgeCollateralAdapter = "<%= AddressZero %>"

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -18,7 +18,7 @@ include = [
     "../rotations/mainnet.toml",
 ]
 
-version = "1.0.155"
+version = "1.0.156"
 
 [var.chain_ids]
 ethereumChainId = "1"
@@ -551,7 +551,7 @@ rseliniWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
 rseliniWithdrawalTvlPercentageLimitUnscaled = "1"
 # -------------------------------------------------------------------
 ramberCollateralAdapter = "<%= AddressZero %>"
-ramberWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
+ramberWithdrawalWindowSize = "0"
 ramberWithdrawalTvlPercentageLimitUnscaled = "1"
 # -------------------------------------------------------------------
 rhedgeCollateralAdapter = "<%= AddressZero %>"


### PR DESCRIPTION
## Summary

Sets \`ramberWithdrawalWindowSize = 0\` in both omnibus tomls so the per-window withdrawal rate limiter is effectively removed for rAmber. Combined with the existing \`ramberWithdrawalTvlPercentageLimitUnscaled = "1"\` (scales to \`1e18\` = 100%), this matches the test-time helper \`removeCollateralWithdrawalLimit\` in [\`BaseReyaForkTest.sol:500-504\`](https://github.com/Reya-Labs/reya-deployments/blob/main/packages/tests/test/reya_common/BaseReyaForkTest.sol#L500).

## Why

Promotes the test-time bypass into production config so small dust withdrawals on rAmber are no longer capped by the per-window rate limiter. The original \`ONE_DAY_IN_SECONDS / 100% TVL\` rate limit was tripping legitimate flows.

## Resulting on-chain state

\`getGlobalCollateralConfig(rAmber)\` will return:

\`\`\`
{
  collateralAdapter: 0x0000000000000000000000000000000000000000,
  withdrawalWindowSize: 0,
  withdrawalTvlPercentageLimit: 1000000000000000000  // 1e18 = 100%
}
\`\`\`

## Diff

Two omnibus tomls, two lines each (one value + one version bump). \`ramberCollateralAdapter\` and \`ramberWithdrawalTvlPercentageLimitUnscaled\` already match the target values and stay untouched.

## Test impact

No fork-check updates needed:
- No test asserts the current rAmber \`withdrawalWindowSize\` or TVL percentage
- WBTC / sREYA / REYA collateral tests assert their own configs independently
- The existing test-time call \`removeCollateralWithdrawalLimit(sec.ramber)\` in [\`PassivePool.fork.c.sol:41\`](https://github.com/Reya-Labs/reya-deployments/blob/main/packages/tests/test/reya_common/trade/PassivePool.fork.c.sol#L41) becomes a no-op for rAmber post-deploy (still useful for other collaterals) — left untouched to avoid drive-by edits

## Verification

\`yarn reya_network:simulate\` against forked mainnet:

\`\`\`
✔ Successfully called setGlobalCollateralConfig(
    0x63FC3F743eE2e70e670864079978a1deB9c18b76,
    {"collateralAdapter_DEPRECATED":"0x0",
     "withdrawalWindowSize":"0",
     "withdrawalTvlPercentageLimit":"1000000000000000000"}
  )
Successfully ran target reya_network:simulate
\`\`\`

## Version bumps

- \`reya_cronos.toml\`: 1.0.140 → 1.0.141
- \`reya_network.toml\`: 1.0.155 → 1.0.156

## Test plan

- [ ] CI green
- [ ] Cannon deploy package generated, sigs collected
- [ ] Multisig execution succeeds
- [ ] Verify on-chain: \`getGlobalCollateralConfig(rAmber).withdrawalWindowSize == 0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated network configuration versions across production environments
  * Modified RAMBER collateral withdrawal window settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reya-Labs/reya-deployments/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->