### PR TITLE
chore(devnet): bump omnibus to feat/perpOB routers (PRO-151)

### DIFF
--- a/packages/tests/src/interfaces/IOrdersGatewayProxyV2.sol
+++ b/packages/tests/src/interfaces/IOrdersGatewayProxyV2.sol
@@ -34,6 +34,9 @@ struct OrderDetails {
     uint64 clientOrderId;
     // Signed reduce-only intent.
     bool reduceOnly;
+    // Signed post-only (maker-only) intent. Order must rest as a maker; a crossing post-only
+    // order is rejected at matching. Valid on GTC/GTT, rejected on IOC and TP/SL.
+    bool postOnly;
     // Order lifetime. Zero means valid until cancelled. Enforced on-chain at settlement.
     uint256 expiresAfter;
     address signer;

--- a/packages/tests/src/utils/OrderDetailsHashing.sol
+++ b/packages/tests/src/utils/OrderDetailsHashing.sol
@@ -5,12 +5,12 @@ import { OrderDetails } from "../../src/interfaces/IOrdersGatewayProxyV2.sol";
 library OrderDetailsHashing {
     bytes32 private constant _ORDER_DETAILS_TYPEHASH = keccak256(
         //solhint-disable-next-line max-line-length
-        "OrderDetails(uint128 accountId,uint128 marketId,uint128 exchangeId,uint8 orderType,int256 quantity,uint256 limitPrice,uint256 triggerPrice,uint8 timeInForce,uint64 clientOrderId,bool reduceOnly,uint256 expiresAfter,address signer,uint256 nonce)"
+        "OrderDetails(uint128 accountId,uint128 marketId,uint128 exchangeId,uint8 orderType,int256 quantity,uint256 limitPrice,uint256 triggerPrice,uint8 timeInForce,uint64 clientOrderId,bool reduceOnly,bool postOnly,uint256 expiresAfter,address signer,uint256 nonce)"
     );
 
     bytes32 private constant _ORDER_TYPEHASH = keccak256(
         //solhint-disable-next-line max-line-length
-        "Order(uint256 verifyingChainId,uint256 deadline,OrderDetails order)OrderDetails(uint128 accountId,uint128 marketId,uint128 exchangeId,uint8 orderType,int256 quantity,uint256 limitPrice,uint256 triggerPrice,uint8 timeInForce,uint64 clientOrderId,bool reduceOnly,uint256 expiresAfter,address signer,uint256 nonce)"
+        "Order(uint256 verifyingChainId,uint256 deadline,OrderDetails order)OrderDetails(uint128 accountId,uint128 marketId,uint128 exchangeId,uint8 orderType,int256 quantity,uint256 limitPrice,uint256 triggerPrice,uint8 timeInForce,uint64 clientOrderId,bool reduceOnly,bool postOnly,uint256 expiresAfter,address signer,uint256 nonce)"
     );
 
     function mockCalculateDigest(
@@ -43,22 +43,31 @@ library OrderDetailsHashing {
     }
 
     function hashOrderDetails(OrderDetails memory order) internal pure returns (bytes32) {
+        // Split into two bytes.concat-ed abi.encode halves (matching the on-chain
+        // OrderHashing.hashOrderDetails) to avoid "stack too deep" once postOnly makes this 14
+        // fields under the legacy (non-viaIR) optimizer. Byte-for-byte identical to a single
+        // abi.encode because every OrderDetails field is a static value type.
         return keccak256(
-            abi.encode(
-                _ORDER_DETAILS_TYPEHASH,
-                order.accountId,
-                order.marketId,
-                order.exchangeId,
-                uint8(order.orderType),
-                order.quantity,
-                order.limitPrice,
-                order.triggerPrice,
-                order.timeInForce,
-                order.clientOrderId,
-                order.reduceOnly,
-                order.expiresAfter,
-                order.signer,
-                order.nonce
+            bytes.concat(
+                abi.encode(
+                    _ORDER_DETAILS_TYPEHASH,
+                    order.accountId,
+                    order.marketId,
+                    order.exchangeId,
+                    uint8(order.orderType),
+                    order.quantity,
+                    order.limitPrice,
+                    order.triggerPrice
+                ),
+                abi.encode(
+                    order.timeInForce,
+                    order.clientOrderId,
+                    order.reduceOnly,
+                    order.postOnly,
+                    order.expiresAfter,
+                    order.signer,
+                    order.nonce
+                )
             )
         );
     }

--- a/packages/tests/test/reya_common/trade/LiquidationPerpOB.fork.c.sol
+++ b/packages/tests/test/reya_common/trade/LiquidationPerpOB.fork.c.sol
@@ -199,8 +199,8 @@ contract LiquidationPerpOBForkCheck is PerpFillForkCheck {
             //                   = counterpartyBase × (openInterest − liquidatedBase) / openInterest,
             // where liquidatedBase is the user's long (1e18) closed by the backstop. On a pristine
             // market (counterparty == sole OI) this is exactly 0; with other OI present it's a residual.
-            int256 expectedCounterpartyBase = counterpartyPosBefore.base
-                * (int256(oiBeforeBackstop) - userPosBefore.base) / int256(oiBeforeBackstop);
+            int256 expectedCounterpartyBase =
+                counterpartyPosBefore.base * (int256(oiBeforeBackstop) - userPosBefore.base) / int256(oiBeforeBackstop);
             assertApproxEqAbs(
                 counterpartyPosAfter.base,
                 expectedCounterpartyBase,

--- a/packages/tests/test/reya_common/trade/LiquidationPerpOB.fork.c.sol
+++ b/packages/tests/test/reya_common/trade/LiquidationPerpOB.fork.c.sol
@@ -169,6 +169,14 @@ contract LiquidationPerpOBForkCheck is PerpFillForkCheck {
             IPassivePerpProxy(sec.perp).getUpdatedPositionInfo(marketId, liqLiquidatorAccountId);
         assertEq(counterpartyPosBefore.base, -1e18, "Counterparty should be short 1 ETH before backstop");
 
+        // Snapshot market open interest before the backstop. ADL socializes the liquidated base
+        // across ALL opposite-side OI proportionally — `ADL.sol::computeADLParams` computes
+        // `adlMultiplier = |liquidatedBase| / openInterest`, scaling every short by `(1 - adlMultiplier)`.
+        // This fork runs against LIVE devnet state, so `openInterest` includes positions beyond this
+        // test's counterparty; the counterparty is therefore only PARTIALLY deleveraged, not fully to
+        // zero. Asserting hard `== 0` only holds when the counterparty is the sole OI (see PRO-157).
+        uint256 oiBeforeBackstop = IPassivePerpProxy(sec.perp).getMarketData(marketId).marketData.openInterest;
+
         // Execute backstop liquidation — keeper is perpSeller's account
         vm.prank(perpSeller);
         ICoreProxy(sec.core).executeBackstopLiquidation(liqUserAccountId, liqLiquidatorAccountId, sec.rusd, 1e18);
@@ -182,12 +190,23 @@ contract LiquidationPerpOBForkCheck is PerpFillForkCheck {
             assertEq(userPos.base, 0, "User position should be closed");
         }
 
-        // In perpOB backstop, the counterparty is ADL'd (force-unwound).
-        // The counterparty had short 1 ETH; after ADL, their position is also closed.
+        // In perpOB backstop, the counterparty is ADL'd (force-unwound) — proportional to OI.
         {
             PerpPosition memory counterpartyPosAfter =
                 IPassivePerpProxy(sec.perp).getUpdatedPositionInfo(marketId, liqLiquidatorAccountId);
-            assertEq(counterpartyPosAfter.base, 0, "Counterparty should be ADL'd to zero");
+
+            // Expected residual = counterpartyBase × (1 − adlMultiplier)
+            //                   = counterpartyBase × (openInterest − liquidatedBase) / openInterest,
+            // where liquidatedBase is the user's long (1e18) closed by the backstop. On a pristine
+            // market (counterparty == sole OI) this is exactly 0; with other OI present it's a residual.
+            int256 expectedCounterpartyBase = counterpartyPosBefore.base
+                * (int256(oiBeforeBackstop) - userPosBefore.base) / int256(oiBeforeBackstop);
+            assertApproxEqAbs(
+                counterpartyPosAfter.base,
+                expectedCounterpartyBase,
+                1e12, // tolerance for PRB-math rounding (~1e-6 ETH)
+                "Counterparty should be ADL'd proportional to market OI"
+            );
 
             // Counterparty realizes profit from the price drop (bought at 3000, closed below 3000)
             assertGt(counterpartyPosAfter.realizedPnL, 0, "Counterparty should have positive realized PnL");

--- a/packages/tests/test/reya_common/trade/PermissionsPerpOB.fork.c.sol
+++ b/packages/tests/test/reya_common/trade/PermissionsPerpOB.fork.c.sol
@@ -167,6 +167,7 @@ contract PermissionsPerpOBForkCheck is BaseReyaForkTest {
                 timeInForce: 0,
                 clientOrderId: 0,
                 reduceOnly: false,
+                postOnly: false,
                 expiresAfter: 0,
                 signer: buyer,
                 nonce: 1
@@ -192,6 +193,7 @@ contract PermissionsPerpOBForkCheck is BaseReyaForkTest {
                 timeInForce: 0,
                 clientOrderId: 0,
                 reduceOnly: false,
+                postOnly: false,
                 expiresAfter: 0,
                 signer: seller,
                 nonce: 1

--- a/packages/tests/test/reya_common/trade/PerpFill.fork.c.sol
+++ b/packages/tests/test/reya_common/trade/PerpFill.fork.c.sol
@@ -101,6 +101,7 @@ contract PerpFillForkCheck is BaseReyaForkTest {
             timeInForce: 0,
             clientOrderId: 0,
             reduceOnly: false,
+            postOnly: false,
             expiresAfter: 0,
             signer: signer,
             nonce: nonce
@@ -884,6 +885,7 @@ contract PerpFillForkCheck is BaseReyaForkTest {
                 timeInForce: 0,
                 clientOrderId: 0,
                 reduceOnly: true,
+                postOnly: false,
                 expiresAfter: 0,
                 signer: perpBuyer,
                 nonce: 2
@@ -1018,6 +1020,7 @@ contract PerpFillForkCheck is BaseReyaForkTest {
                 timeInForce: 0,
                 clientOrderId: 0,
                 reduceOnly: true,
+                postOnly: false,
                 expiresAfter: 0,
                 signer: perpBuyer,
                 nonce: 2

--- a/packages/tests/test/reya_common/trade/SpotPerpOB.fork.c.sol
+++ b/packages/tests/test/reya_common/trade/SpotPerpOB.fork.c.sol
@@ -91,6 +91,7 @@ contract SpotPerpOBForkCheck is BaseReyaForkTest {
             timeInForce: 0,
             clientOrderId: 0,
             reduceOnly: false,
+            postOnly: false,
             expiresAfter: 0,
             signer: signer,
             nonce: nonce

--- a/packages/tests/test/reya_devnet/trade/Permissions.fork.t.sol
+++ b/packages/tests/test/reya_devnet/trade/Permissions.fork.t.sol
@@ -35,4 +35,10 @@ contract PermissionsForkTest is ReyaForkTest, PermissionsPerpOBForkCheck {
     function test_Devnet_WsExecRelayerExecutionPermission() public view {
         check_ConditionalOrdersExecutionAllowlist(0x6623C4a8e54549d5dB1ACb666B13f9c046DFD5B2);
     }
+
+    /// @dev co_execution_bot3 — the Rust wallet-manager relayer; must be on the
+    /// conditional_orders allowlist or its batchExecuteFill reverts FeatureUnavailable.
+    function test_Devnet_WalletManagerRelayerExecutionPermission() public view {
+        check_ConditionalOrdersExecutionAllowlist(0xB04ce54876A8017ae7785A3f4218308BC8fBb724);
+    }
 }

--- a/packages/tomls/src/devnet/orders_gateway/feature_flags.toml
+++ b/packages/tomls/src/devnet/orders_gateway/feature_flags.toml
@@ -50,3 +50,13 @@ args = [
     "<%= settings.co_execution_bot2 %>",
 ]
 depends = ["invoke.upgrade_orders_gateway_proxy"]
+
+[invoke.orders_gateway_enable_co_execution_bot_3]
+target = ["OrdersGatewayProxy"]
+fromCall.func = "owner"
+func = "addToFeatureFlagAllowlist"
+args = [
+    "<%= keccak256(hexlify('conditional_orders')) %>",
+    "<%= settings.co_execution_bot3 %>",
+]
+depends = ["invoke.upgrade_orders_gateway_proxy"]

--- a/packages/tomls/src/omnibus/reya_devnet.toml
+++ b/packages/tomls/src/omnibus/reya_devnet.toml
@@ -22,7 +22,7 @@ include = [
     "../devnet/collateral_pools/collateral_pool_1.toml",
 ]
 
-version = "1.0.6"
+version = "1.0.7"
 
 ###############################################################################
 # Existing Cronos Contract Addresses (reused, not redeployed)
@@ -51,14 +51,14 @@ passivePoolExchangeFeeCollectorOwner = "0xaE173a960084903b1d278Ff9E3A81DeD822755
 ###############################################################################
 [var.cannonClonePackages]
 coreProxyPackage = "reya-core:1.0.0@proxy"
-coreRouterPackage = "reya-core:1.0.32@router"
+coreRouterPackage = "reya-core:1.0.33@router"
 coreAccountNftRouterPackage = "reya-core:1.0.2@account-nft-router"
 passivePerpProxyPackage = "reya-instrument-passive-perp:1.0.0@proxy"
-passivePerpRouterPackage = "reya-instrument-passive-perp:1.0.53@router"
+passivePerpRouterPackage = "reya-instrument-passive-perp:1.0.54@router"
 ordersGatewayProxyPackage = "reya-orders-gateway:1.0.1@proxy"
-ordersGatewayRouterPackage = "reya-orders-gateway:1.0.23@router"
+ordersGatewayRouterPackage = "reya-orders-gateway:1.0.24@router"
 peripheryProxyPackage = "reya-periphery:1.0.0@proxy"
-peripheryRouterPackage = "reya-periphery:1.0.16@router"
+peripheryRouterPackage = "reya-periphery:1.0.17@router"
 
 ###############################################################################
 # Account NFT

--- a/packages/tomls/src/omnibus/reya_devnet.toml
+++ b/packages/tomls/src/omnibus/reya_devnet.toml
@@ -22,7 +22,7 @@ include = [
     "../devnet/collateral_pools/collateral_pool_1.toml",
 ]
 
-version = "1.0.7"
+version = "1.0.8"
 
 ###############################################################################
 # Existing Cronos Contract Addresses (reused, not redeployed)

--- a/packages/tomls/src/omnibus/reya_devnet.toml
+++ b/packages/tomls/src/omnibus/reya_devnet.toml
@@ -145,6 +145,7 @@ oraclePusher2 = "0xa91Cc8B9109B5A1DBBb453CaaE63630BDCa09Fd3"
 [var.co_execution_bots]
 co_execution_bot1 = "0xc9A01c03AEE926B89b83F7781b15B822807E1d33"
 co_execution_bot2 = "0x6623C4a8e54549d5dB1ACb666B13f9c046DFD5B2" # ws-exec relayer
+co_execution_bot3 = "0xB04ce54876A8017ae7785A3f4218308BC8fBb724" # rust wallet-manager relayer
 
 ###############################################################################
 # Fee Configuration Bots


### PR DESCRIPTION
## What

Upgrades the devnet (reya-cronos, chainId `89346162`) omnibus to the freshly-published `feat/perpOB` router packages, which carry the PR #698 internal-audit fixes (PRO-12) — including the new canonical `AccountCreatedV2` creation-ledger event.

| Package | From | To |
|---|---|---|
| `reya-core` | `1.0.32@router` | **`1.0.33@router`** |
| `reya-instrument-passive-perp` | `1.0.53@router` | **`1.0.54@router`** |
| `reya-orders-gateway` | `1.0.23@router` | **`1.0.24@router`** |
| `reya-periphery` | `1.0.16@router` | **`1.0.17@router`** |
| omnibus `version` | `1.0.6` | **`1.0.7`** |

Proxies and `coreAccountNftRouter` (`1.0.2`) are unchanged — the account-NFT modules were untouched by PRO-12.

## No config changes
Config-toml schema is unchanged. The one behavioral audit change (B.1.6 — fill-price deviation now references the on-chain mark price instead of the oracle) is **inert on devnet**: `market1Eth_markPriceMaxDeviationUnscaled` and `market1Eth_fillPriceMaxDeviationUnscaled` are both `0` (disabled). Dust is also disabled (`dustAccountId = 0`).

## Upgrade mechanics
Router-bump in place via `--upgrade-from reya-devnet-omnibus:latest@main` → **proxy addresses stay stable**. Off-chain address config is unchanged; only ABIs + event handling change (tracked in **PRO-188**).

## Before merge / deploy
- [ ] `reya_devnet:simulate` applies clean (routers resolve to new versions, proxies upgrade, no storage-layout complaints)
- [ ] `reya_devnet:test` fork tests pass (update any referencing changed ABIs: removed `AccountUpdated`, new `AccountCreatedV2`, `FailedUnifiedFillBytes` core-marketId, `PriceDeviationTooLarge.referencePrice`)
- [ ] Real upgrade executed + `reya-devnet-omnibus:1.0.7@main` published
- [ ] Off-chain re-point (PRO-188)

Part of PRO-151. Published-package IPFS hashes are in the build logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Reya Devnet omnibus configuration to version 1.0.7 with refreshed router component package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->