### PR TITLE
chore(omnibus): tighten collateral withdrawal limits (PRO-286)

### DIFF
--- a/packages/tests/test/reya_common/collaterals/WbtcCollateral.fork.c.sol
+++ b/packages/tests/test/reya_common/collaterals/WbtcCollateral.fork.c.sol
@@ -73,8 +73,8 @@ contract WbtcCollateralForkCheck is BaseReyaForkTest {
         (GlobalCollateralConfig memory globalConfig,) = ICoreProxy(sec.core).getGlobalCollateralConfig(sec.wbtc);
 
         assertEq(globalConfig.collateralAdapter, address(0), "collateralAdapter should be zero address");
-        assertEq(globalConfig.withdrawalWindowSize, 1, "withdrawalWindowSize mismatch");
-        assertEq(globalConfig.withdrawalTvlPercentageLimit, 1e18, "withdrawalTvlPercentageLimit mismatch");
+        assertEq(globalConfig.withdrawalWindowSize, 10_800, "withdrawalWindowSize mismatch");
+        assertEq(globalConfig.withdrawalTvlPercentageLimit, 0.25e18, "withdrawalTvlPercentageLimit mismatch");
     }
 
     function check_wbtc_spot_market_config(WbtcSpotMarketConfigExpectations memory expected) internal view {

--- a/packages/tomls/src/core/configs/tokens/srusd.toml
+++ b/packages/tomls/src/core/configs/tokens/srusd.toml
@@ -4,7 +4,7 @@ fromCall.func = "owner"
 func = "setGlobalCollateralConfig"
 args = [
     "<%= contracts.SRUSDProxy.address %>",
-    { collateralAdapter = "<%= settings.srusdCollateralAdapter %>", withdrawalWindowSize = "<%= settings.srusdWithdrawalWindowSize %>", withdrawalTvlPercentageLimit = "<%= parseEther(settings.srusdWithdrawalTvlPercentageLimitUnscaled)  %>" },
+    { collateralAdapter_DEPRECATED = "<%= settings.srusdCollateralAdapter %>", withdrawalWindowSize = "<%= settings.srusdWithdrawalWindowSize %>", withdrawalTvlPercentageLimit = "<%= parseEther(settings.srusdWithdrawalTvlPercentageLimitUnscaled)  %>" },
 ]
 depends = [
     'invoke.upgrade_core_proxy',

--- a/packages/tomls/src/core/configs/tokens/weth.toml
+++ b/packages/tomls/src/core/configs/tokens/weth.toml
@@ -4,7 +4,7 @@ fromCall.func = "owner"
 func = "setGlobalCollateralConfig"
 args = [
     "<%= contracts.WETHProxy.address %>",
-    { collateralAdapter = "<%= settings.wethCollateralAdapter %>", withdrawalWindowSize = "<%= settings.wethWithdrawalWindowSize %>", withdrawalTvlPercentageLimit = "<%= parseEther(settings.wethWithdrawalTvlPercentageLimitUnscaled)  %>" },
+    { collateralAdapter_DEPRECATED = "<%= settings.wethCollateralAdapter %>", withdrawalWindowSize = "<%= settings.wethWithdrawalWindowSize %>", withdrawalTvlPercentageLimit = "<%= parseEther(settings.wethWithdrawalTvlPercentageLimitUnscaled)  %>" },
 ]
 depends = [
     'invoke.upgrade_core_proxy',

--- a/packages/tomls/src/core/configs/tokens/wsteth.toml
+++ b/packages/tomls/src/core/configs/tokens/wsteth.toml
@@ -4,7 +4,7 @@ fromCall.func = "owner"
 func = "setGlobalCollateralConfig"
 args = [
     "<%= contracts.WSTETHProxy.address %>",
-    { collateralAdapter = "<%= settings.wstethCollateralAdapter %>", withdrawalWindowSize = "<%= settings.wstethWithdrawalWindowSize %>", withdrawalTvlPercentageLimit = "<%= parseEther(settings.wstethWithdrawalTvlPercentageLimitUnscaled)  %>" },
+    { collateralAdapter_DEPRECATED = "<%= settings.wstethCollateralAdapter %>", withdrawalWindowSize = "<%= settings.wstethWithdrawalWindowSize %>", withdrawalTvlPercentageLimit = "<%= parseEther(settings.wstethWithdrawalTvlPercentageLimitUnscaled)  %>" },
 ]
 depends = [
     'invoke.upgrade_core_proxy',

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -548,11 +548,11 @@ srusdWithdrawalTvlPercentageLimitUnscaled = "0.1"
 # -------------------------------------------------------------------
 rseliniCollateralAdapter = "<%= AddressZero %>"
 rseliniWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
-rseliniWithdrawalTvlPercentageLimitUnscaled = "1"
+rseliniWithdrawalTvlPercentageLimitUnscaled = "0"
 # -------------------------------------------------------------------
 ramberCollateralAdapter = "<%= AddressZero %>"
 ramberWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
-ramberWithdrawalTvlPercentageLimitUnscaled = "1"
+ramberWithdrawalTvlPercentageLimitUnscaled = "0"
 # -------------------------------------------------------------------
 rhedgeCollateralAdapter = "<%= AddressZero %>"
 rhedgeWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"

--- a/packages/tomls/src/omnibus/reya_network.toml
+++ b/packages/tomls/src/omnibus/reya_network.toml
@@ -18,7 +18,7 @@ include = [
     "../rotations/mainnet.toml",
 ]
 
-version = "1.0.156"
+version = "1.0.157"
 
 [var.chain_ids]
 ethereumChainId = "1"
@@ -516,15 +516,15 @@ reyaEthereumWithdrawFeeUnscaled = "1"
 [var.global_collateral_configs]
 rusdCollateralAdapter = "<%= AddressZero %>"
 rusdWithdrawalWindowSize = "<%= settings.THREE_HOURS_IN_SECONDS %>"
-rusdWithdrawalTvlPercentageLimitUnscaled = "0.4"
+rusdWithdrawalTvlPercentageLimitUnscaled = "0.1"
 # -------------------------------------------------------------------
 wethCollateralAdapter = "<%= AddressZero %>"
-wethWithdrawalWindowSize = "1"
-wethWithdrawalTvlPercentageLimitUnscaled = "1"
+wethWithdrawalWindowSize = "<%= settings.THREE_HOURS_IN_SECONDS %>"
+wethWithdrawalTvlPercentageLimitUnscaled = "0.25"
 # -------------------------------------------------------------------
 wbtcCollateralAdapter = "<%= AddressZero %>"
-wbtcWithdrawalWindowSize = "1"
-wbtcWithdrawalTvlPercentageLimitUnscaled = "1"
+wbtcWithdrawalWindowSize = "<%= settings.THREE_HOURS_IN_SECONDS %>"
+wbtcWithdrawalTvlPercentageLimitUnscaled = "0.25"
 # -------------------------------------------------------------------
 usdeCollateralAdapter = "<%= AddressZero %>"
 usdeWithdrawalWindowSize = "1"
@@ -543,8 +543,8 @@ sdeusdWithdrawalWindowSize = "1"
 sdeusdWithdrawalTvlPercentageLimitUnscaled = "1"
 # -------------------------------------------------------------------
 srusdCollateralAdapter = "<%= AddressZero %>"
-srusdWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
-srusdWithdrawalTvlPercentageLimitUnscaled = "0.3"
+srusdWithdrawalWindowSize = "<%= settings.THREE_HOURS_IN_SECONDS %>"
+srusdWithdrawalTvlPercentageLimitUnscaled = "0.1"
 # -------------------------------------------------------------------
 rseliniCollateralAdapter = "<%= AddressZero %>"
 rseliniWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
@@ -559,8 +559,8 @@ rhedgeWithdrawalWindowSize = "<%= settings.ONE_DAY_IN_SECONDS %>"
 rhedgeWithdrawalTvlPercentageLimitUnscaled = "0"
 # -------------------------------------------------------------------
 wstethCollateralAdapter = "<%= AddressZero %>"
-wstethWithdrawalWindowSize = "1"
-wstethWithdrawalTvlPercentageLimitUnscaled = "1"
+wstethWithdrawalWindowSize = "<%= settings.THREE_HOURS_IN_SECONDS %>"
+wstethWithdrawalTvlPercentageLimitUnscaled = "0.25"
 # -------------------------------------------------------------------
 reyaCollateralAdapter = "<%= AddressZero %>"
 reyaWithdrawalWindowSize = "1"


### PR DESCRIPTION
## Summary
Tighten the per-collateral **global withdrawal rate-limits** (`setGlobalCollateralConfig`) on the Reya **mainnet** omnibus to shrink the blast radius of an exploit / oracle fault / mass-exit.

Linear: [PRO-286](https://linear.app/reya-labs/issue/PRO-286/tighten-collateral-withdrawal-limits-on-reya-mainnet-omnibus)

## Changes (mainnet only)

**1. Withdrawal limits** — rate-limited collaterals move to a 3h rolling window; LM/pool tokens frozen:

| Token | Window (old → new) | TVL % (old → new) |
|---|---|---|
| rUSD | 3h → 3h | 40% → **10%** |
| srUSD | 1d → 3h | 30% → **10%** |
| WETH | 1s → 3h | 100% → **25%** |
| WBTC | 1s → 3h | 100% → **25%** |
| wstETH | 1s → 3h | 100% → **25%** |
| rSELINI | 1d → 1d | 100% → **0% (frozen)** |
| rAMBER | 1d → 1d | 100% → **0% (frozen)** |

rSELINI/rAMBER are frozen for normal egress and will be opened up manually (multisig) at rebalance time. rHEDGE is already 0%. All other collaterals (USDe, sUSDe, deUSD, sdeUSD, REYA, sREYA) are unchanged. Omnibus `version` 1.0.156 → 1.0.157.

**2. Struct field-name fix** — the srUSD/WETH/wstETH token configs used the stale struct key `collateralAdapter`; the live CoreProxy ABI renamed it `collateralAdapter_DEPRECATED` (already used by rUSD/WBTC). Without this, those three invokes **skip** with `InvalidAddressError: Address "undefined"` when re-run, so the new limits would silently not apply. Fixed to match.

## Verification
- `yarn lint:check` and `yarn build`: pass.
- `yarn reya_network:test` (Cannon, forked mainnet): the build applies **all 7** re-run `setGlobalCollateralConfig` invokes with **no skips** and no "deployment not fully completed" warning; `WbtcCollateral` fork checks pass **5/5**, including the updated `test_wbtc_global_collateral_config()` assertion.
- WBTC fork-check assertion updated to match the new config (`1` / `1e18` → `10_800` / `0.25e18`).

## Rollout
This repo change is the source of truth; it takes effect on-chain once the multisig executes the cannon-generated `setGlobalCollateralConfig` Safe transactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
